### PR TITLE
Rename core video properties.

### DIFF
--- a/project/video/src/main/kotlin/com/pajato/argus/core/video/Data.kt
+++ b/project/video/src/main/kotlin/com/pajato/argus/core/video/Data.kt
@@ -10,27 +10,27 @@ enum class ErrorKey {
 
 sealed class Video
 
-class CoreVideo(val id: Long, val data: MutableMap<AttributeType, Attribute> = mutableMapOf()) : Video() {
+class CoreVideo(val videoId: Long, val videoData: MutableMap<AttributeType, Attribute> = mutableMapOf()) : Video() {
     var archived = false
     fun updateAttribute(attribute: Attribute, type: UpdateType) {
         fun updateUsingAdd()  {
-            val videoAttribute = data[attribute.attrType]
+            val videoAttribute = videoData[attribute.attrType]
             if (videoAttribute == null || attribute.updateByReplace)
-                data[attribute.attrType] = attribute
+                videoData[attribute.attrType] = attribute
             else
                 videoAttribute.update(attribute, type)
         }
         fun updateUsingRemove() {
-            if (data.containsKey(attribute.attrType) && attribute.updateByReplace)
-                data.remove(attribute.attrType)
+            if (videoData.containsKey(attribute.attrType) && attribute.updateByReplace)
+                videoData.remove(attribute.attrType)
             else
-                data[attribute.attrType]?.update(attribute, type)
+                videoData[attribute.attrType]?.update(attribute, type)
         }
 
         when (type) {
             UpdateType.Add -> updateUsingAdd()
             UpdateType.Remove -> updateUsingRemove()
-            UpdateType.RemoveAll -> if (data.containsKey(attribute.attrType)) data.remove(attribute.attrType)
+            UpdateType.RemoveAll -> if (videoData.containsKey(attribute.attrType)) videoData.remove(attribute.attrType)
             else -> return
         }
     }

--- a/project/video/src/main/kotlin/com/pajato/argus/core/video/Persister.kt
+++ b/project/video/src/main/kotlin/com/pajato/argus/core/video/Persister.kt
@@ -59,17 +59,17 @@ class Persister(private val eventStore: File) {
     }
 
     fun archive(video: CoreVideo) {
-        persist(ArchiveEvent(video.id))
+        persist(ArchiveEvent(video.videoId))
     }
 
     fun register(video: CoreVideo, name: String) {
-        persist(RegisterEvent(video.id, name))
+        persist(RegisterEvent(video.videoId, name))
     }
 
     fun update(video: CoreVideo, type: UpdateType) {
         fun persistAttribute(attr: Attribute) {
             fun putString(value: String) {
-                persist(UpdateEvent(type, video.id, attr.attrType, value))
+                persist(UpdateEvent(type, video.videoId, attr.attrType, value))
             }
             fun putArray(values: List<String>) {
                 for (value in values)
@@ -87,7 +87,7 @@ class Persister(private val eventStore: File) {
             }
         }
 
-        for (attr in video.data.values)
+        for (attr in video.videoData.values)
             persistAttribute(attr)
     }
 

--- a/project/video/src/main/kotlin/com/pajato/argus/core/video/Registrar.kt
+++ b/project/video/src/main/kotlin/com/pajato/argus/core/video/Registrar.kt
@@ -23,7 +23,7 @@ class Registrar(file: File) : VideoRegistrar {
     override fun findAll(filterData: MutableSet<Attribute>): List<Video> {
         fun matches(video: CoreVideo): Boolean {
             filterData.forEach {
-                val attribute = video.data[it.attrType] ?: return false
+                val attribute = video.videoData[it.attrType] ?: return false
                 if (!attribute.isEqual(it)) return false
             }
             return true
@@ -57,10 +57,10 @@ class Registrar(file: File) : VideoRegistrar {
             fun processAttributes(video: CoreVideo) {
                 fun registerVideoWithAttributes(video: CoreVideo, attrs: MutableMap<AttributeType, Attribute>) {
                     videoList.add(video)
-                    val id = video.id
+                    val id = video.videoId
                     idMap[name] = id
                     videoMap[id] = video
-                    video.data.putAll(attrs)
+                    video.videoData.putAll(attrs)
                 }
 
                 val attributes : MutableMap<AttributeType, Attribute> = mutableMapOf()

--- a/project/video/src/test/kotlin/com/pajato/argus/core/video/PersisterTest.kt
+++ b/project/video/src/test/kotlin/com/pajato/argus/core/video/PersisterTest.kt
@@ -86,9 +86,9 @@ internal class PersisterTest {
         setup()
         val videoList = uut.load()
         Assertions.assertEquals(1, videoList.size)
-        Assertions.assertEquals(1, videoList[0].data.size)
-        Assertions.assertEquals(id, videoList[0].id)
-        Assertions.assertTrue((videoList[0].data[AttributeType.Name]!!.isEqual(Name(name))))
+        Assertions.assertEquals(1, videoList[0].videoData.size)
+        Assertions.assertEquals(id, videoList[0].videoId)
+        Assertions.assertTrue((videoList[0].videoData[AttributeType.Name]!!.isEqual(Name(name))))
     }
 
     @Test
@@ -104,8 +104,8 @@ internal class PersisterTest {
         setup()
         val videoList = uut.load()
         Assertions.assertEquals(1, videoList.size)
-        Assertions.assertEquals(2, videoList[0].data.size)
-        val attribute = videoList[0].data[AttributeType.Cast]
+        Assertions.assertEquals(2, videoList[0].videoData.size)
+        val attribute = videoList[0].videoData[AttributeType.Cast]
         if (attribute is Cast)
             Assertions.assertEquals(2, attribute.performers.size)
         else
@@ -128,8 +128,8 @@ internal class PersisterTest {
         setup()
         val videoList = uut.load()
         Assertions.assertEquals(1, videoList.size)
-        Assertions.assertEquals(2, videoList[0].data.size)
-        val attribute = videoList[0].data[AttributeType.Directors]
+        Assertions.assertEquals(2, videoList[0].videoData.size)
+        val attribute = videoList[0].videoData[AttributeType.Directors]
         if (attribute is Directors)
             Assertions.assertEquals(2, attribute.directors.size)
         else
@@ -151,7 +151,7 @@ internal class PersisterTest {
         setup()
         val videoList = uut.load()
         Assertions.assertEquals(1, videoList.size)
-        Assertions.assertEquals(1, videoList[0].data.size)
+        Assertions.assertEquals(1, videoList[0].videoData.size)
         repo.delete()
     }
 

--- a/project/video/src/test/kotlin/com/pajato/argus/core/video/RegistrarTest.kt
+++ b/project/video/src/test/kotlin/com/pajato/argus/core/video/RegistrarTest.kt
@@ -72,7 +72,7 @@ class RegistrarTest {
         var data = mutableSetOf<Attribute>(Name("Video 1"))
         Assertions.assertEquals(1, interactor.findAll(data).size)
 
-        val id = (video as? CoreVideo)?.id ?: -1L
+        val id = (video as? CoreVideo)?.videoId ?: -1L
         Assertions.assertTrue(id >= now)
 
         data = mutableSetOf()
@@ -94,7 +94,7 @@ class RegistrarTest {
         Assertions.assertTrue(repo.exists() && repo.isFile && repo.length() > 0L)
         Assertions.assertTrue(video is CoreVideo)
 
-        val id = (video as? CoreVideo)?.id ?: -1L
+        val id = (video as? CoreVideo)?.videoId ?: -1L
         Assertions.assertTrue(interactor.findById(id) is CoreVideo)
         Assertions.assertEquals(video, interactor.findById(id))
         Assertions.assertTrue(interactor.findById(23) is VideoError)
@@ -137,7 +137,7 @@ class RegistrarTest {
         val name = "Video To Find By Id"
         val okVideo = interactor.register(name)
         if (okVideo is CoreVideo) {
-            val id = okVideo.id
+            val id = okVideo.videoId
             assertEquals(okVideo, interactor.findById(id))
         } else fail("Expected a CoreVideo but found a VideoError object!")
         val errorVideo = interactor.findById(-1)
@@ -166,16 +166,16 @@ class RegistrarTest {
                         releaseAttribute,
                         //seriesAttribute,
                         typeAttribute)
-                interactor.update(video.id, attributes, UpdateType.Add)
-                assertEquals(newName, (video.data[nameAttribute.attrType] as Name).name)
-                assertEquals(directorsList, (video.data[directorsAttribute.attrType] as Directors).directors)
-                interactor.update(video.id, mutableSetOf(Cast(mutableListOf("Star2"))), UpdateType.Remove)
-                assertTrue(video.data[AttributeType.Cast] != null)
-                interactor.update(video.id, mutableSetOf(Provider("HBO")), UpdateType.RemoveAll)
-                assertFalse(video.data.contains(AttributeType.Provider))
-                interactor.update(video.id, mutableSetOf(), UpdateType.CoverageDefault)
+                interactor.update(video.videoId, attributes, UpdateType.Add)
+                assertEquals(newName, (video.videoData[nameAttribute.attrType] as Name).name)
+                assertEquals(directorsList, (video.videoData[directorsAttribute.attrType] as Directors).directors)
+                interactor.update(video.videoId, mutableSetOf(Cast(mutableListOf("Star2"))), UpdateType.Remove)
+                assertTrue(video.videoData[AttributeType.Cast] != null)
+                interactor.update(video.videoId, mutableSetOf(Provider("HBO")), UpdateType.RemoveAll)
+                assertFalse(video.videoData.contains(AttributeType.Provider))
+                interactor.update(video.videoId, mutableSetOf(), UpdateType.CoverageDefault)
                 assertTrue(interactor.update(-23, mutableSetOf(), UpdateType.Add) is VideoError)
-                assertTrue(interactor.update(video.id, mutableSetOf(), UpdateType.CoverageDefault) is CoreVideo)
+                assertTrue(interactor.update(video.videoId, mutableSetOf(), UpdateType.CoverageDefault) is CoreVideo)
             }
             is VideoError -> fail("Expected CoreVideo object but found a VideoError with key ${video.key}")
         }

--- a/project/video/src/test/kotlin/com/pajato/argus/core/video/VideoTest.kt
+++ b/project/video/src/test/kotlin/com/pajato/argus/core/video/VideoTest.kt
@@ -87,8 +87,8 @@ class DataTest {
     @Test
     fun `Core video has a correct id and no attributes`() {
         val video = CoreVideo(0)
-        assertEquals(0, video.id)
-        assertEquals(0, video.data.size)
+        assertEquals(0, video.videoId)
+        assertEquals(0, video.videoData.size)
     }
 
     @Test
@@ -179,7 +179,7 @@ class DataTest {
     @Test
     fun `do a remove and removeAll on a core video object`() {
         val video = CoreVideo(0)
-        video.data[AttributeType.Provider] = Provider("HBO")
+        video.videoData[AttributeType.Provider] = Provider("HBO")
         video.updateAttribute(Provider(""), UpdateType.Remove)
         video.updateAttribute(Provider(""), UpdateType.RemoveAll)
         video.updateAttribute(Cast(mutableListOf()), UpdateType.Remove)


### PR DESCRIPTION
Rationale:
=========

This commit applies a fix for the review comment that the properties id and data should be less general and more specific.